### PR TITLE
On API 18 and later, Vault uses the Android KeyStore to wrap an

### DIFF
--- a/AndroidVault/vault/src/main/java/com/bottlerocketstudios/vault/keys/wrapper/AbstractAndroidKeystoreSecretKeyWrapper.java
+++ b/AndroidVault/vault/src/main/java/com/bottlerocketstudios/vault/keys/wrapper/AbstractAndroidKeystoreSecretKeyWrapper.java
@@ -141,13 +141,29 @@ public abstract class AbstractAndroidKeystoreSecretKeyWrapper implements SecretK
 
     @Override
     public synchronized byte[] wrap(SecretKey key) throws GeneralSecurityException, IOException {
-        mCipher.init(Cipher.WRAP_MODE, getKeyPair().getPublic());
+
+        AlgorithmParameterSpec spec = buildCipherAlgorithmParameterSpec();
+
+        if (spec == null) {
+            mCipher.init(Cipher.WRAP_MODE, getKeyPair().getPublic());
+        } else {
+            mCipher.init(Cipher.WRAP_MODE, getKeyPair().getPublic(), spec);
+        }
+
         return mCipher.wrap(key);
     }
 
     @Override
     public synchronized SecretKey unwrap(byte[] blob, String wrappedKeyAlgorithm) throws GeneralSecurityException, IOException {
-        mCipher.init(Cipher.UNWRAP_MODE, getKeyPair().getPrivate());
+
+        AlgorithmParameterSpec spec = buildCipherAlgorithmParameterSpec();
+
+        if (spec == null) {
+            mCipher.init(Cipher.UNWRAP_MODE, getKeyPair().getPrivate());
+        } else {
+            mCipher.init(Cipher.UNWRAP_MODE, getKeyPair().getPrivate(), spec);
+        }
+
         return (SecretKey) mCipher.unwrap(blob, wrappedKeyAlgorithm, Cipher.SECRET_KEY);
     }
 
@@ -157,6 +173,10 @@ public abstract class AbstractAndroidKeystoreSecretKeyWrapper implements SecretK
         final KeyStore keyStore = KeyStore.getInstance(EncryptionConstants.ANDROID_KEY_STORE);
         keyStore.load(null);
         keyStore.deleteEntry(mAlias);
+    }
+
+    public AlgorithmParameterSpec buildCipherAlgorithmParameterSpec() {
+        return null;
     }
 
     public boolean testKey() throws GeneralSecurityException, IOException {

--- a/AndroidVault/vault/src/main/java/com/bottlerocketstudios/vault/keys/wrapper/AndroidOaepKeystoreSecretKeyWrapper.java
+++ b/AndroidVault/vault/src/main/java/com/bottlerocketstudios/vault/keys/wrapper/AndroidOaepKeystoreSecretKeyWrapper.java
@@ -21,6 +21,11 @@ import android.content.Context;
 import android.security.keystore.KeyProperties;
 
 import java.security.GeneralSecurityException;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
 
 /**
  * Wraps {@link javax.crypto.SecretKey} instances using a public/private key pair stored in
@@ -40,6 +45,10 @@ public class AndroidOaepKeystoreSecretKeyWrapper extends AbstractAndroidKeystore
     protected static final String[] ENCRYPTION_PADDING;
     protected static final String[] BLOCK_MODES;
     protected static final String[] DIGESTS;
+
+    //Cipher Algorithm Spec Params
+    protected static final String MESSAGE_DIGEST_ALGORITHM_NAME = "SHA-256";
+    protected static final String MASK_GENERATION_FUNCTION_ALGORITHM_NAME = "MGF1";
 
     static {
         ENCRYPTION_PADDING = new String[] {KeyProperties.ENCRYPTION_PADDING_RSA_OAEP};
@@ -76,5 +85,14 @@ public class AndroidOaepKeystoreSecretKeyWrapper extends AbstractAndroidKeystore
     @Override
     protected String[] getDigests() {
         return DIGESTS;
+    }
+
+    @Override
+    public AlgorithmParameterSpec buildCipherAlgorithmParameterSpec() {
+        return new OAEPParameterSpec(
+                MESSAGE_DIGEST_ALGORITHM_NAME,
+                MASK_GENERATION_FUNCTION_ALGORITHM_NAME,
+                MGF1ParameterSpec.SHA1,
+                PSource.PSpecified.DEFAULT);
     }
 }


### PR DESCRIPTION
On API 18 and later, Vault uses the Android KeyStore to wrap an
encryption key. The key is provided by the Bouncy Castle provider which
has a known issue.

"RSA OAEP Ciphers are parameterized by two digests: the "main"/content
digest and the MGF1 digest. Java Standard Names document
(https://docs.oracle.com/javase/8/docs/technotes/guides/security/
StandardNames.html#Cipher) defines RSA OAEP algorithm/transformation
padding names in the form OAEPWith<digest>AndMGF1Padding (e.g.,
OAEPWithSHA-256AndMGF1Padding). Reference Implementation (RI) Cipher
implementations set the "main" OAEP digest to the one in the
algorithm/transformation name while keeping the MGF1 digest defaulted to
SHA-1. Bouncy Castle's RSA OAEP Cipher implementation, however, set both
digests to the one in the algorithm/transformation. This makes RI and BC
incompatible. " - https://issuetracker.google.com/issues/37075898#comment7

The resolve the issue, we need to provide an OAEPParameterSpec and set
the correct digest values when initializing the ciphers and
wrapping/unwrapping the key.