### PR TITLE
Add support for composite builds

### DIFF
--- a/AndroidVault/build.gradle
+++ b/AndroidVault/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1'

--- a/AndroidVault/vault/build.gradle
+++ b/AndroidVault/vault/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.jfrog.artifactory-upload'
 
 group = "com.bottlerocketstudios"
-version = "1.4.2"
+version = "1.4.3-SNAPSHOT"
 
 project.ext.artifactory_artifactid = "vault"
 project.ext.artifactory_packaging = "jar"

--- a/AndroidVault/vault/build.gradle
+++ b/AndroidVault/vault/build.gradle
@@ -19,6 +19,13 @@ project.ext.bundle_name = "vault"
 android {
     compileSdkVersion 26
 
+    // Need build types so composite builds will work with sample application
+    buildTypes {
+        release {
+        }
+        debug {
+        }
+    }
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 26
@@ -28,7 +35,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 android.libraryVariants.all { variant ->

--- a/AndroidVault/vault/src/main/AndroidManifest.xml
+++ b/AndroidVault/vault/src/main/AndroidManifest.xml
@@ -1,11 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.bottlerocketstudios.vault">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:icon="@drawable/ic_launcher"
-        >
-
-    </application>
-
 </manifest>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add the jcenter repository and include the library in your project with the comp
 
         dependencies {
             ...
-            compile 'com.bottlerocketstudios:vault:1.4.1'
+            compile 'com.bottlerocketstudios:vault:1.4.2'
         }
 
 In rare cases where you need to pull a snapshot build to help troubleshoot the develop branch, snapshots are hosted by JFrog. You should not ship a release using the snapshot library as the actual binary referenced by snapshot is going to change with every build of the develop branch. In the best case you will have irreproducible builds. In the worst case, human extinction. In some more likely middle case, you will have buggy or experimental code in your released app.
@@ -70,7 +70,7 @@ In rare cases where you need to pull a snapshot build to help troubleshoot the d
          
          dependencies {
             ...
-            compile 'com.bottlerocketstudios:vault:1.4.2-SNAPSHOT'
+            compile 'com.bottlerocketstudios:vault:1.4.3-SNAPSHOT'
          }
 
 #### Sample Application

--- a/SampleApplication/app/build.gradle
+++ b/SampleApplication/app/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.bottlerocketstudios.vaultsampleapplication"
         minSdkVersion 17
-        targetSdkVersion 23
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -29,6 +28,6 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.bottlerocketstudios:vault:1.4.0-SNAPSHOT'
+    compile 'com.android.support:appcompat-v7:28.0.0'
+    compile 'com.bottlerocketstudios:vault:1.4.2'
 }

--- a/SampleApplication/app/build.gradle
+++ b/SampleApplication/app/build.gradle
@@ -26,8 +26,8 @@ repositories {
 
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:28.0.0'
-    compile 'com.bottlerocketstudios:vault:1.4.2'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.bottlerocketstudios:vault:1.4.2'
 }

--- a/SampleApplication/build.gradle
+++ b/SampleApplication/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/SampleApplication/gradle/wrapper/gradle-wrapper.properties
+++ b/SampleApplication/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 21 10:57:50 CDT 2016
+#Thu Nov 15 15:50:16 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/SampleApplication/settings.gradle
+++ b/SampleApplication/settings.gradle
@@ -1,1 +1,8 @@
 include ':app'
+
+rootProject.name='root'
+includeBuild('../AndroidVault') {
+    dependencySubstitution {
+        substitute module("com.bottlerocketstudios:vault") with project(':vault')
+    }
+}


### PR DESCRIPTION
  This way, any changes to the local directory can be immediately used by the sample application.
   
   * Requires a root build.gradle file though.
   * Gradle version must match.
   * Consistent build variants. 
   * Remove redundant application tag in AndroidManifest.xml
